### PR TITLE
gh-42: Better, more reliable fix for link hitboxes being misaligned on wide-drawn characters.

### DIFF
--- a/terminal.c
+++ b/terminal.c
@@ -4715,7 +4715,8 @@ static void do_paint(Terminal *term, Context ctx, int may_optimise)
 			termline *lp = lineptr(term->disptop + i);
 
 			for (j = 0; j < term->cols; j++) {
-				urlhack_putchar((char)(lp->chars[j].chr & CHAR_MASK), j < term->cols-1 && lp->chars[j+1].chr == UCSWIDE ? 1 : 0);
+				unsigned long tchar = lp->chars[j].chr;
+				urlhack_putchar(tchar & CHAR_MASK ? (char)(tchar & CHAR_MASK) : ' ');
 			}
 
 			unlineptr(lp);

--- a/urlhack.cpp
+++ b/urlhack.cpp
@@ -111,9 +111,9 @@ void urlhack_reset()
 
 
 
-void urlhack_putchar(char ch, int wide)
+void urlhack_putchar(char ch)
 {
-	char r00fles[3] = { ch, wide ? ch : 0, 0 };
+	char r00fles[2] = { ch, 0 };
 	text_mass.append(r00fles);
 }
 

--- a/windows/urlhack.h
+++ b/windows/urlhack.h
@@ -19,7 +19,7 @@ extern int urlhack_mouse_old_x, urlhack_mouse_old_y, urlhack_current_region;
 
 void urlhack_reset();
 void urlhack_go_find_me_some_hyperlinks(int screen_width);
-void urlhack_putchar(char ch, int width);
+void urlhack_putchar(char ch);
 text_region urlhack_get_link_region(int index);
 
 void urlhack_clear_link_regions();


### PR DESCRIPTION
gh-42: Better, more reliable fix for link hitboxes being misaligned on wide-drawn characters.
