### PR TITLE
Add obfuscated ssh feature to the PuTTYTray

### DIFF
--- a/arc4random.h
+++ b/arc4random.h
@@ -1,0 +1,491 @@
+/*==========================================================================
+ * Not sure where I found this, but it is required for the obfuscated KEX
+ * handshake.
+ *
+ * --Mr. Hinky Dink
+ * =========================================================================
+ */
+
+/* ==========================================================================
+ * arc4random.h - Re-implementation of OpenBSD's arc4random().
+ * --------------------------------------------------------------------------
+ * Copyright (c) 2008  William Ahern
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ==========================================================================
+ */
+#ifndef BSD_STDLIB_ARC4RANDOM_H
+#define BSD_STDLIB_ARC4RANDOM_H
+
+#ifndef HAVE_ARC4RANDOM
+#if defined __OpenBSD__	\
+ || defined __FreeBSD__	\
+ || defined __NetBSD__	\
+ || defined __APPLE__
+#define HAVE_ARC4RANDOM	1
+#else
+#define HAVE_ARC4RANDOM	0
+#endif
+#endif
+typedef unsigned long  uint32_t;
+#if !HAVE_ARC4RANDOM
+
+#if !_WIN32
+#include <stdint.h>	/* uint32_t */
+#endif
+
+#include <stdarg.h>	/* va_list va_start() va_arg() va_end() */
+
+#include <string.h>	/* memset(3) */
+
+#include <time.h>	/* time(3) clock(3) */
+
+#if _WIN32
+#include <process.h>	/* _getpid() */
+#include <windows.h>	/* LoadLibrary() GetProcAddress() FreeLibrary() */
+#include <wincrypt.h>	/* CryptAcquireContext() CryptGenRandom() CryptReleaseContext() */
+
+
+
+#else
+#include <unistd.h>	/* getpid(2) */
+#include <sys/types.h>
+#include <sys/sysctl.h>	/* CTL_KERN KERN_RANDOM RANDOM_UUID sysctl(2) */
+#endif
+
+#if _REENTRANT
+#if _WIN32
+#include <windows.h>	/* CRITICAL_SECTION InitializeCriticalSection() EnterCriticalSection() LeaveCriticalSection() InterlockedCompareExchange() InterlockedExchange() */
+#else
+#include <pthread.h>	/* pthread_mutex_t pthread_mutex_lock(3) pthread_mutex_unlock(3) */
+#endif
+#endif
+
+
+#define ARC4_STIR		0
+#define ARC4_ADDRANDOM		1
+#define ARC4_RANDOM		2
+#define ARC4_RANDOM_BUF		3
+#define ARC4_RANDOM_UNIFORM	4
+
+#if _WIN32
+static unsigned long arc4random_(int op, volatile int locked, ...) {
+#else
+static inline uint32_t arc4random_(int op, volatile int locked, ...) {
+#endif
+	static struct {
+		unsigned char s[256];
+		unsigned char i, j;
+		int c;
+#if _REENTRANT
+#if _WIN32
+		struct {
+			volatile LONG init;
+			CRITICAL_SECTION cs;
+		} mux;
+#else
+		pthread_mutex_t mux;
+#endif
+#endif
+	} arc4 = {
+		{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		  0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		  0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+		  0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+		  0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
+		  0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+		  0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+		  0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+		  0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
+		  0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f,
+		  0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57,
+		  0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f,
+		  0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67,
+		  0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f,
+		  0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77,
+		  0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+		  0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
+		  0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f,
+		  0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97,
+		  0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f,
+		  0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+		  0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+		  0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7,
+		  0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf,
+		  0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7,
+		  0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf,
+		  0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7,
+		  0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf,
+		  0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7,
+		  0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef,
+		  0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
+		  0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff }, };
+	unsigned long rval = 0;
+
+#if _REENTRANT
+	if (!locked++) {
+#if _WIN32
+		volatile LONG init;
+
+		do {
+			switch (init = InterlockedCompareExchange((LONG *)&arc4.mux.init, 1, 0)) {
+			case 2: /* initialized already. */
+				break;
+			case 1: /* try again. */
+				Sleep(1);
+
+				break;
+			case 0: /* must initialize. */
+				InitializeCriticalSection(&arc4.mux.cs);
+
+				InterlockedExchange((LONG *)&arc4.mux.init, 2);
+
+				break;
+			}
+		} while (1 == init);
+
+		EnterCriticalSection(&arc4.mux.cs);
+#else
+		pthread_mutex_lock(&arc4.mux);
+#endif
+	}
+#endif
+
+
+	switch (op) {
+	case ARC4_STIR: {
+		union {
+			time_t tim;
+			clock_t clk;
+			int pid;
+			unsigned char bytes[128];
+		} rnd;
+		int n;
+
+		memset(&rnd, '\0', sizeof rnd);
+
+		rnd.tim	^= time(0);
+		rnd.clk	^= clock();
+
+#if _WIN32
+		rnd.pid	^= _getpid();
+#else
+		rnd.pid	^= getpid();
+#endif
+
+#if __linux
+		{
+			int mib[] = { CTL_KERN, KERN_RANDOM, RANDOM_UUID };
+			unsigned char uuid[128];
+			size_t len, n;
+
+			for (len = 0; len < sizeof uuid; len += n) {
+				n	= sizeof uuid - len;
+
+				if (0 != sysctl(mib, sizeof mib / sizeof mib[0], &uuid[len], &n, (void *)0, 0))
+					break;
+			}
+
+			for (n = 0; n < len && n < sizeof rnd; n++)
+				rnd.bytes[n]	^= uuid[n];
+
+			goto stir;
+		}
+#endif
+
+#if _WIN32
+		{
+			HMODULE lib	= 0;
+			HCRYPTPROV ctx	= 0;
+			// I had to add the WINAPI casts below to stop crashing in Debug build
+			//   - Hinky
+			struct {
+				BOOL (WINAPI *acquire)(HCRYPTPROV *, LPCSTR, LPCSTR, DWORD, DWORD);
+				BOOL (WINAPI *genrandom)(HCRYPTPROV, DWORD, BYTE *);
+				BOOL (WINAPI *release)(HCRYPTPROV, DWORD);
+			} crypt;
+			unsigned char bytes[sizeof rnd.bytes];
+
+			if (!(lib = LoadLibrary(TEXT("ADVAPI32.DLL"))))
+				goto unload;
+
+			if (!(crypt.acquire = (BOOL (WINAPI*)())GetProcAddress(lib, "CryptAcquireContextA"))
+			||  !(crypt.genrandom = (BOOL (WINAPI*)())GetProcAddress(lib, "CryptGenRandom"))
+			||  !(crypt.release = (BOOL (WINAPI*)())GetProcAddress(lib, "CryptReleaseContext")))
+				goto unload;
+
+			if (!crypt.acquire(&ctx, 0, 0, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+				goto unload;
+
+			if (!crypt.genrandom(ctx, sizeof bytes, bytes))
+				goto unload;
+
+			for (n = 0; n < sizeof bytes && n < sizeof rnd.bytes; n++)
+				rnd.bytes[n]	^= bytes[n];
+
+unload:
+			if (ctx)
+				crypt.release(ctx, 0);
+
+			if (lib)
+				FreeLibrary(lib);
+
+			goto stir;
+		}
+#endif
+
+stir:
+		arc4random_(ARC4_ADDRANDOM, locked, rnd.bytes, sizeof rnd.bytes);
+
+		arc4.c	= 1600000 + (256 / 4);
+
+		/*
+		 * OpenBSD only discards 256 bytes. Probably safer to
+		 * discard at least 768, but w'ever.
+		 */
+		for (n = 0; n < (256 / 4); n++)
+			arc4random_(ARC4_RANDOM, locked);
+
+		break;
+	}
+
+	case ARC4_ADDRANDOM: {
+		va_list ap;
+		unsigned char *src;
+		int len, n;
+		unsigned char si;
+
+		va_start(ap, locked);
+
+		src	= va_arg(ap, unsigned char *);
+		len	= va_arg(ap, int);
+
+		va_end(ap);
+
+		if (len <= 0)
+			break;
+
+		/*
+		 * From David Mazieres' OpenBSD code. Seems to be a novel
+		 * admixture of RC4's key setup and byte stream generator.
+		 */
+		arc4.i--;
+		for (n = 0; n < 256; n++) {
+			arc4.i	= (arc4.i + 1) % 256;
+			si	= arc4.s[arc4.i];
+			arc4.j	= (arc4.j + si + src[n % len]) % 256;
+
+			arc4.s[arc4.i]	= arc4.s[arc4.j];
+			arc4.s[arc4.j]	= si;
+		}
+		arc4.j	= arc4.i;
+
+		break;
+	}
+
+	case ARC4_RANDOM: {
+		unsigned char si, sj;
+		int n;
+
+		if (arc4.c <= 0)
+			arc4random_(ARC4_STIR, locked);
+
+		/*
+		 * Again from David Maziere's OpenBSD code.
+		 */
+		for (n = 0; n < 4; n++) {
+			rval	<<= 8;
+
+			arc4.i		= (arc4.i + 1) % 256;
+			si		= arc4.s[arc4.i];
+			arc4.j		= (arc4.j + si) % 256;
+			sj		= arc4.s[arc4.j];
+			arc4.s[arc4.i]	= sj;
+			arc4.s[arc4.j]	= si;
+
+			rval		|= arc4.s[(si + sj) % 256];
+		}
+
+		arc4.c	-= 4;
+
+		break;
+	}
+
+	case ARC4_RANDOM_BUF: {
+		va_list ap;
+		unsigned char *dst;
+		size_t lim;
+
+		va_start(ap, locked);
+
+		dst	= va_arg(ap, unsigned char *);
+		lim	= va_arg(ap, size_t);
+
+		va_end(ap);
+
+		while (lim > 0) {
+			uint32_t r	= arc4random_(ARC4_RANDOM, locked);
+
+			switch (lim % 4) {
+			case 0:
+				dst[--lim]	= (r >> 24U);
+			case 3:
+				dst[--lim]	= (r >> 16U);
+			case 2:
+				dst[--lim]	= (r >> 8U);
+			case 1:
+				dst[--lim]	= (r >> 0U);
+			} /* switch (lim % 4) */
+		} /* while (lim) */
+
+		break;
+	}
+
+	default:
+		break;
+	} /* switch (op) */
+
+#if _REENTRANT
+	if (locked == 1) {
+#if _WIN32
+		LeaveCriticalSection(&arc4.mux.cs);
+#else
+		pthread_mutex_unlock(&arc4.mux);
+#endif
+	}
+#endif
+
+	return rval;
+} /* arc4random_() */
+
+#define arc4random_stir()		arc4random_(ARC4_STIR, 0)
+#define arc4random_addrandom(p, n)	arc4random_(ARC4_ADDRANDOM, 0, (p), (n))
+#define arc4random()			arc4random_(ARC4_RANDOM, 0)
+#define arc4random_buf(p, n)		arc4random_(ARC4_RANDOM_BUF, 0, (p), (n))
+
+#ifndef HAVE_ARC4RANDOM_BUF
+#define HAVE_ARC4RANDOM_BUF	1
+#endif
+
+#ifndef HAVE_ARC4RANDOM_UNIFORM
+#define HAVE_ARC4RANDOM_UNIFORM	1
+#endif
+
+#endif /* !HAVE_ARC4RANDOM */
+
+
+#ifndef HAVE_ARC4RANDOM_BUF
+#if defined __OpenBSD__ || defined __FreeBSD__
+
+#include <sys/param.h>	/* OpenBSD, __FreeBSD_version */
+
+#if OpenBSD >= 200811 || __FreeBSD_version >= 800107
+#define HAVE_ARC4RANDOM_BUF	1
+#else
+#define HAVE_ARC4RANDOM_BUF	0
+#endif
+
+#else
+#define HAVE_ARC4RANDOM_BUF	0
+#endif
+#endif
+
+#if !HAVE_ARC4RANDOM_BUF
+
+#include <stddef.h>	/* size_t */
+
+static inline void arc4random_buf(void *dst, size_t lim) {
+		while (lim > 0) {
+			unsigned long r	= arc4random();
+
+			switch (lim % 4) {
+			case 0:
+				((unsigned char *)dst)[--lim]	= (r >> 24U);
+			case 3:
+				((unsigned char *)dst)[--lim]	= (r >> 16U);
+			case 2:
+				((unsigned char *)dst)[--lim]	= (r >> 8U);
+			case 1:
+				((unsigned char *)dst)[--lim]	= (r >> 0U);
+			} /* switch (lim % 4) */
+		} /* while (lim) */
+} /* arc4random_buf() */
+
+#endif /* !HAVE_ARC4RANDOM_BUF */
+
+
+#endif /* !BSD_STDLIB_ARC4RANDOM_H */
+
+
+#if 0
+
+void *malloc(size_t);
+void free(void *);
+
+#include <stdio.h>	/* printf(3) */
+#include <ctype.h>	/* isdigit(3) */
+
+int main(int argc, char *argv[]) {
+	unsigned long i, j, n = 1600000;
+	unsigned char *p;
+
+	if (argc > 1) {
+		for (n = 0; isdigit(*argv[1]); argv[1]++) {
+			n	*= 10;
+			n	+= *argv[1] - '0';
+		}
+	}
+
+	for (i = 0; i < n; i++)
+		printf("%lu\n", (unsigned long)arc4random());
+
+	if (argc > 2) {
+		for (n = 0; isdigit(*argv[2]); argv[2]++) {
+			n	*= 10;
+			n	+= *argv[2] - '0';
+		}
+	} else
+		n	= 0xffff & arc4random();
+
+	p	= malloc(n);
+
+	arc4random_buf(p, n);
+
+	for (i = 0; i < n;) {
+		char hex[16]	= "0123456789abcdef";
+		char ln[56];
+
+		for (j = 0; i < n && j < 16; j++, i++) {
+			ln[(j * 3) + 0]	= hex[0x0f & (p[i] >> 4)];
+			ln[(j * 3) + 1]	= hex[0x0f & (p[i] >> 0)];
+			ln[(j * 3) + 2]	= ' ';
+		}
+
+		fwrite(ln, 3, j, stdout);
+		fputc('\n', stdout);
+	}
+
+	free(p);
+
+	return 0;
+} /* main() */
+
+#endif
+

--- a/bsd-arc4random.c
+++ b/bsd-arc4random.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 1999,2000,2004 Damien Miller <djm@mindrot.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "defines.h"
+
+#include <sys/types.h>
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+//#include "log.h"
+
+#ifndef HAVE_ARC4RANDOM
+
+#include <openssl/rand.h>
+#include <openssl/rc4.h>
+#include <openssl/err.h>
+
+/* Size of key to use */
+#define SEED_SIZE 20
+
+/* Number of bytes to reseed after */
+#define REKEY_BYTES	(1 << 24)
+
+static int rc4_ready = 0;
+static RC4_KEY rc4;
+
+void arc4random_stir(void);
+
+unsigned int
+arc4random(void)
+{
+	unsigned int r = 0;
+	static int first_time = 1;
+
+	if (rc4_ready <= 0) {
+		if (first_time)
+			seed_rng();
+		first_time = 0;
+		arc4random_stir();
+	}
+
+	RC4(&rc4, sizeof(r), (unsigned char *)&r, (unsigned char *)&r);
+
+	rc4_ready -= sizeof(r);
+	
+	return(r);
+}
+
+void
+arc4random_stir(void)
+{
+	unsigned char rand_buf[SEED_SIZE];
+	int i;
+
+	memset(&rc4, 0, sizeof(rc4));
+//	if (RAND_bytes(rand_buf, sizeof(rand_buf)) <= 0)
+//		fatal("Couldn't obtain random bytes (error %ld)",
+//		    ERR_get_error());
+	RC4_set_key(&rc4, sizeof(rand_buf), rand_buf);
+
+	/*
+	 * Discard early keystream, as per recommendations in:
+	 * http://www.wisdom.weizmann.ac.il/~itsik/RC4/Papers/Rc4_ksa.ps
+	 */
+	for(i = 0; i <= 256; i += sizeof(rand_buf))
+		RC4(&rc4, sizeof(rand_buf), rand_buf, rand_buf);
+
+	memset(rand_buf, 0, sizeof(rand_buf));
+
+	rc4_ready = REKEY_BYTES;
+}
+#endif /* !HAVE_ARC4RANDOM */
+
+#ifndef ARC4RANDOM_BUF
+void
+arc4random_buf(void *_buf, size_t n)
+{
+	size_t i;
+	u_int32_t r = 0;
+	char *buf = (char *)_buf;
+
+	for (i = 0; i < n; i++) {
+		if (i % 4 == 0)
+			r = arc4random();
+		buf[i] = r & 0xff;
+		r >>= 8;
+	}
+	i = r = 0;
+}
+#endif /* !HAVE_ARC4RANDOM_BUF */
+
+#ifndef ARC4RANDOM_UNIFORM
+/*
+ * Calculate a uniformly distributed random number less than upper_bound
+ * avoiding "modulo bias".
+ *
+ * Uniformity is achieved by generating new random numbers until the one
+ * returned is outside the range [0, 2**32 % upper_bound).  This
+ * guarantees the selected random number will be inside
+ * [2**32 % upper_bound, 2**32) which maps back to [0, upper_bound)
+ * after reduction modulo upper_bound.
+ */
+u_int32_t
+arc4random_uniform(u_int32_t upper_bound)
+{
+	u_int32_t r, min;
+
+	if (upper_bound < 2)
+		return 0;
+
+#if (ULONG_MAX > 0xffffffffUL)
+	min = 0x100000000UL % upper_bound;
+#else
+	/* Calculate (2**32 % upper_bound) avoiding 64-bit math */
+	if (upper_bound > 0x80000000)
+		min = 1 + ~upper_bound;		/* 2**32 - upper_bound */
+	else {
+		/* (2**32 - (x * 2)) % x == 2**32 % x when x <= 2**31 */
+		min = ((0xffffffff - (upper_bound * 2)) + 1) % upper_bound;
+	}
+#endif
+
+	/*
+	 * This could theoretically loop forever but each retry has
+	 * p > 0.5 (worst case, usually far better) of selecting a
+	 * number inside the range we need, so it should rarely need
+	 * to re-roll.
+	 */
+	for (;;) {
+		r = arc4random();
+		if (r >= min)
+			break;
+	}
+
+	return r % upper_bound;
+}
+#endif /* !HAVE_ARC4RANDOM_UNIFORM */

--- a/cmdline.c
+++ b/cmdline.c
@@ -467,6 +467,25 @@ int cmdline_process_param(char *p, char *value, int need_save, Config *cfg)
 	cfg->keyfile = filename_from_str(value);
     }
 
+	// hinky
+    if (!strcmp(p, "-Z")) {
+	RETURN(2);
+	UNAVAILABLE_IN(TOOLTYPE_NONNETWORK);
+	SAVEABLE(0);
+	strcpy(cfg->obfuscate_keyword, value);
+	cfg->obfuscate = TRUE;
+	cfg->sshprot = 2;
+    }
+
+    if (!strcmp(p, "-z")) {
+	RETURN(1);
+	UNAVAILABLE_IN(TOOLTYPE_NONNETWORK);
+	SAVEABLE(0);
+	cfg->obfuscate = TRUE;
+    cfg->sshprot = 2; 
+	}
+    // end hinky
+
     if (!strcmp(p, "-4") || !strcmp(p, "-ipv4")) {
 	RETURN(1);
 	SAVEABLE(1);

--- a/config.c
+++ b/config.c
@@ -2164,6 +2164,23 @@ void setup_config_box(struct controlbox *b, int midsession,
 			 I(16));
 	    ctrl_text(s, "(Use 1M for 1 megabyte, 1G for 1 gigabyte etc)",
 		      HELPCTX(ssh_kex_repeat));
+// Hinky's obfuscated-openssh options
+		if (!midsession){ 
+			s = ctrl_getset(b, "Connection/SSH/Kex", "none",
+				    "Obfuscation options");
+			ctrl_checkbox(s, "Enable key exchange obfuscation", 'i',
+					 HELPCTX(obfuscate),
+					 dlg_stdcheckbox_handler,
+					 I(offsetof(Config,obfuscate)));
+			c = ctrl_editbox(s, "Keyword (OPTIONAL):", 'r', 100,
+					 HELPCTX(obfuscate_keyword),
+					 dlg_stdeditbox_handler, I(offsetof(Config,obfuscate_keyword)),
+					 I(sizeof(((Config *)0)->obfuscate_keyword)));
+			c->editbox.password = 1;
+			ctrl_text(s, "WARNING: Keyword is stored in clear text!",
+	                 HELPCTX(obfuscate_keyword));
+
+		}
 	}
 
 	if (!midsession) {

--- a/defines.h
+++ b/defines.h
@@ -1,0 +1,679 @@
+/*
+ * Copyright (c) 1999-2003 Damien Miller.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _DEFINES_H
+#define _DEFINES_H
+
+/* $Id: defines.h,v 1.153 2009/02/01 11:19:54 dtucker Exp $ */
+
+
+/* Constants */
+
+#if defined(HAVE_DECL_SHUT_RD) && HAVE_DECL_SHUT_RD == 0
+enum
+{
+  SHUT_RD = 0,		/* No more receptions.  */
+  SHUT_WR,			/* No more transmissions.  */
+  SHUT_RDWR			/* No more receptions or transmissions.  */
+};
+# define SHUT_RD   SHUT_RD
+# define SHUT_WR   SHUT_WR
+# define SHUT_RDWR SHUT_RDWR
+#endif
+
+#ifndef IPTOS_LOWDELAY
+# define IPTOS_LOWDELAY          0x10
+# define IPTOS_THROUGHPUT        0x08
+# define IPTOS_RELIABILITY       0x04
+# define IPTOS_LOWCOST           0x02
+# define IPTOS_MINCOST           IPTOS_LOWCOST
+#endif /* IPTOS_LOWDELAY */
+
+#ifndef MAXPATHLEN
+# ifdef PATH_MAX
+#  define MAXPATHLEN PATH_MAX
+# else /* PATH_MAX */
+#  define MAXPATHLEN 64
+/* realpath uses a fixed buffer of size MAXPATHLEN, so force use of ours */
+#  ifndef BROKEN_REALPATH
+#   define BROKEN_REALPATH 1
+#  endif /* BROKEN_REALPATH */
+# endif /* PATH_MAX */
+#endif /* MAXPATHLEN */
+
+#ifndef PATH_MAX
+# ifdef _POSIX_PATH_MAX
+# define PATH_MAX _POSIX_PATH_MAX
+# endif
+#endif
+
+#if defined(HAVE_DECL_MAXSYMLINKS) && HAVE_DECL_MAXSYMLINKS == 0
+# define MAXSYMLINKS 5
+#endif
+
+#ifndef STDIN_FILENO
+# define STDIN_FILENO    0
+#endif
+#ifndef STDOUT_FILENO
+# define STDOUT_FILENO   1
+#endif
+#ifndef STDERR_FILENO
+# define STDERR_FILENO   2
+#endif
+
+#ifndef NGROUPS_MAX	/* Disable groupaccess if NGROUP_MAX is not set */
+#ifdef NGROUPS
+#define NGROUPS_MAX NGROUPS
+#else
+#define NGROUPS_MAX 0
+#endif
+#endif
+
+#if defined(HAVE_DECL_O_NONBLOCK) && HAVE_DECL_O_NONBLOCK == 0
+# define O_NONBLOCK      00004	/* Non Blocking Open */
+#endif
+
+#ifndef S_ISDIR
+# define S_ISDIR(mode)	(((mode) & (_S_IFMT)) == (_S_IFDIR))
+#endif /* S_ISDIR */
+
+#ifndef S_ISREG
+# define S_ISREG(mode)	(((mode) & (_S_IFMT)) == (_S_IFREG))
+#endif /* S_ISREG */
+
+#ifndef S_ISLNK
+# define S_ISLNK(mode)	(((mode) & S_IFMT) == S_IFLNK)
+#endif /* S_ISLNK */
+
+#ifndef S_IXUSR
+# define S_IXUSR			0000100	/* execute/search permission, */
+# define S_IXGRP			0000010	/* execute/search permission, */
+# define S_IXOTH			0000001	/* execute/search permission, */
+# define _S_IWUSR			0000200	/* write permission, */
+# define S_IWUSR			_S_IWUSR	/* write permission, owner */
+# define S_IWGRP			0000020	/* write permission, group */
+# define S_IWOTH			0000002	/* write permission, other */
+# define S_IRUSR			0000400	/* read permission, owner */
+# define S_IRGRP			0000040	/* read permission, group */
+# define S_IROTH			0000004	/* read permission, other */
+# define S_IRWXU			0000700	/* read, write, execute */
+# define S_IRWXG			0000070	/* read, write, execute */
+# define S_IRWXO			0000007	/* read, write, execute */
+#endif /* S_IXUSR */
+
+#if !defined(MAP_ANON) && defined(MAP_ANONYMOUS)
+#define MAP_ANON MAP_ANONYMOUS
+#endif
+
+#ifndef MAP_FAILED
+# define MAP_FAILED ((void *)-1)
+#endif
+
+/* *-*-nto-qnx doesn't define this constant in the system headers */
+#ifdef MISSING_NFDBITS
+# define	NFDBITS (8 * sizeof(unsigned long))
+#endif
+
+/*
+SCO Open Server 3 has INADDR_LOOPBACK defined in rpc/rpc.h but
+including rpc/rpc.h breaks Solaris 6
+*/
+#ifndef INADDR_LOOPBACK
+#define INADDR_LOOPBACK ((u_long)0x7f000001)
+#endif
+
+/* Types */
+
+/* If sys/types.h does not supply intXX_t, supply them ourselves */
+/* (or die trying) */
+
+typedef long  int32_t;
+
+
+typedef unsigned char u_int8_t;
+typedef unsigned short u_int16_t;
+typedef unsigned long  u_int32_t;
+
+/* 64-bit types */
+#ifndef HAVE_INT64_T
+# if (SIZEOF_LONG_INT == 8)
+typedef long int int64_t;
+# else
+#  if (SIZEOF_LONG_LONG_INT == 8)
+typedef long long int int64_t;
+#  endif
+# endif
+#endif
+#ifndef HAVE_U_INT64_T
+# if (SIZEOF_LONG_INT == 8)
+typedef unsigned long int u_int64_t;
+# else
+#  if (SIZEOF_LONG_LONG_INT == 8)
+typedef unsigned long long int u_int64_t;
+#  endif
+# endif
+#endif
+
+#ifndef HAVE_U_CHAR
+typedef unsigned char u_char;
+# define HAVE_U_CHAR
+#endif /* HAVE_U_CHAR */
+
+#ifndef SIZE_T_MAX
+#define SIZE_T_MAX ULONG_MAX
+#endif /* SIZE_T_MAX */
+
+#ifndef HAVE_SIZE_T
+typedef unsigned int size_t;
+# define HAVE_SIZE_T
+//# define SIZE_T_MAX UINT_MAX
+#endif /* HAVE_SIZE_T */
+
+#ifndef HAVE_SSIZE_T
+typedef int ssize_t;
+# define HAVE_SSIZE_T
+#endif /* HAVE_SSIZE_T */
+
+#ifndef HAVE_CLOCK_T
+typedef long clock_t;
+# define HAVE_CLOCK_T
+#endif /* HAVE_CLOCK_T */
+
+#ifndef HAVE_SA_FAMILY_T
+typedef int sa_family_t;
+# define HAVE_SA_FAMILY_T
+#endif /* HAVE_SA_FAMILY_T */
+
+#ifndef HAVE_PID_T
+typedef int pid_t;
+# define HAVE_PID_T
+#endif /* HAVE_PID_T */
+
+#ifndef HAVE_SIG_ATOMIC_T
+typedef int sig_atomic_t;
+# define HAVE_SIG_ATOMIC_T
+#endif /* HAVE_SIG_ATOMIC_T */
+
+#ifndef HAVE_MODE_T
+typedef int mode_t;
+# define HAVE_MODE_T
+#endif /* HAVE_MODE_T */
+
+#if !defined(HAVE_SS_FAMILY_IN_SS) && defined(HAVE___SS_FAMILY_IN_SS)
+# define ss_family __ss_family
+#endif /* !defined(HAVE_SS_FAMILY_IN_SS) && defined(HAVE_SA_FAMILY_IN_SS) */
+
+#ifndef HAVE_SYS_UN_H
+struct	sockaddr_un {
+	short	sun_family;		/* AF_UNIX */
+	char	sun_path[108];		/* path name (gag) */
+};
+#endif /* HAVE_SYS_UN_H */
+
+#ifndef HAVE_IN_ADDR_T
+typedef u_int32_t	in_addr_t;
+#endif
+
+#if defined(BROKEN_SYS_TERMIO_H) && !defined(_STRUCT_WINSIZE)
+#define _STRUCT_WINSIZE
+struct winsize {
+      unsigned short ws_row;          /* rows, in characters */
+      unsigned short ws_col;          /* columns, in character */
+      unsigned short ws_xpixel;       /* horizontal size, pixels */
+      unsigned short ws_ypixel;       /* vertical size, pixels */
+};
+#endif
+
+/* *-*-nto-qnx does not define this type in the system headers */
+#ifdef MISSING_FD_MASK
+ typedef unsigned long int	fd_mask;
+#endif
+
+/* Paths */
+
+#ifndef _PATH_BSHELL
+# define _PATH_BSHELL "/bin/sh"
+#endif
+
+#ifdef USER_PATH
+# ifdef _PATH_STDPATH
+#  undef _PATH_STDPATH
+# endif
+# define _PATH_STDPATH USER_PATH
+#endif
+
+#ifndef _PATH_STDPATH
+# define _PATH_STDPATH "/usr/bin:/bin:/usr/sbin:/sbin"
+#endif
+
+#ifndef SUPERUSER_PATH
+# define SUPERUSER_PATH	_PATH_STDPATH
+#endif
+
+#ifndef _PATH_DEVNULL
+# define _PATH_DEVNULL "/dev/null"
+#endif
+
+#ifndef MAIL_DIRECTORY
+# define MAIL_DIRECTORY "/var/spool/mail"
+#endif
+
+#ifndef MAILDIR
+# define MAILDIR MAIL_DIRECTORY
+#endif
+
+#if !defined(_PATH_MAILDIR) && defined(MAILDIR)
+# define _PATH_MAILDIR MAILDIR
+#endif /* !defined(_PATH_MAILDIR) && defined(MAILDIR) */
+
+#ifndef _PATH_NOLOGIN
+# define _PATH_NOLOGIN "/etc/nologin"
+#endif
+
+/* Define this to be the path of the xauth program. */
+#ifdef XAUTH_PATH
+#define _PATH_XAUTH XAUTH_PATH
+#endif /* XAUTH_PATH */
+
+/* derived from XF4/xc/lib/dps/Xlibnet.h */
+#ifndef X_UNIX_PATH
+#  ifdef __hpux
+#    define X_UNIX_PATH "/var/spool/sockets/X11/%u"
+#  else
+#    define X_UNIX_PATH "/tmp/.X11-unix/X%u"
+#  endif
+#endif /* X_UNIX_PATH */
+#define _PATH_UNIX_X X_UNIX_PATH
+
+#ifndef _PATH_TTY
+# define _PATH_TTY "/dev/tty"
+#endif
+
+/* Macros */
+
+#if defined(HAVE_LOGIN_GETCAPBOOL) && defined(HAVE_LOGIN_CAP_H)
+# define HAVE_LOGIN_CAP
+#endif
+
+#ifndef MAX
+# define MAX(a,b) (((a)>(b))?(a):(b))
+# define MIN(a,b) (((a)<(b))?(a):(b))
+#endif
+
+#ifndef roundup
+# define roundup(x, y)   ((((x)+((y)-1))/(y))*(y))
+#endif
+
+#ifndef timersub
+#define timersub(a, b, result)					\
+   do {								\
+      (result)->tv_sec = (a)->tv_sec - (b)->tv_sec;		\
+      (result)->tv_usec = (a)->tv_usec - (b)->tv_usec;		\
+      if ((result)->tv_usec < 0) {				\
+	 --(result)->tv_sec;					\
+	 (result)->tv_usec += 1000000;				\
+      }								\
+   } while (0)
+#endif
+
+#ifndef TIMEVAL_TO_TIMESPEC
+#define	TIMEVAL_TO_TIMESPEC(tv, ts) {					\
+	(ts)->tv_sec = (tv)->tv_sec;					\
+	(ts)->tv_nsec = (tv)->tv_usec * 1000;				\
+}
+#endif
+
+#ifndef TIMESPEC_TO_TIMEVAL
+#define	TIMESPEC_TO_TIMEVAL(tv, ts) {					\
+	(tv)->tv_sec = (ts)->tv_sec;					\
+	(tv)->tv_usec = (ts)->tv_nsec / 1000;				\
+}
+#endif
+
+#ifndef __P
+# define __P(x) x
+#endif
+
+#if !defined(IN6_IS_ADDR_V4MAPPED)
+# define IN6_IS_ADDR_V4MAPPED(a) \
+	((((u_int32_t *) (a))[0] == 0) && (((u_int32_t *) (a))[1] == 0) && \
+	 (((u_int32_t *) (a))[2] == htonl (0xffff)))
+#endif /* !defined(IN6_IS_ADDR_V4MAPPED) */
+
+#if !defined(__GNUC__) || (__GNUC__ < 2)
+# define __attribute__(x)
+#endif /* !defined(__GNUC__) || (__GNUC__ < 2) */
+
+#if !defined(HAVE_ATTRIBUTE__SENTINEL__) && !defined(__sentinel__)
+# define __sentinel__
+#endif
+
+#if !defined(HAVE_ATTRIBUTE__BOUNDED__) && !defined(__bounded__)
+# define __bounded__(x, y, z)
+#endif
+
+#if !defined(HAVE_ATTRIBUTE__NONNULL__) && !defined(__nonnull__)
+# define __nonnull__(x)
+#endif
+
+/* *-*-nto-qnx doesn't define this macro in the system headers */
+#ifdef MISSING_HOWMANY
+# define howmany(x,y)	(((x)+((y)-1))/(y))
+#endif
+
+#ifndef OSSH_ALIGNBYTES
+#define OSSH_ALIGNBYTES	(sizeof(int) - 1)
+#endif
+#ifndef __CMSG_ALIGN
+#define	__CMSG_ALIGN(p) (((u_int)(p) + OSSH_ALIGNBYTES) &~ OSSH_ALIGNBYTES)
+#endif
+
+/* Length of the contents of a control message of length len */
+#ifndef CMSG_LEN
+#define	CMSG_LEN(len)	(__CMSG_ALIGN(sizeof(struct cmsghdr)) + (len))
+#endif
+
+/* Length of the space taken up by a padded control message of length len */
+#ifndef CMSG_SPACE
+#define	CMSG_SPACE(len)	(__CMSG_ALIGN(sizeof(struct cmsghdr)) + __CMSG_ALIGN(len))
+#endif
+
+/* given pointer to struct cmsghdr, return pointer to data */
+#ifndef CMSG_DATA
+#define CMSG_DATA(cmsg) ((u_char *)(cmsg) + __CMSG_ALIGN(sizeof(struct cmsghdr)))
+#endif /* CMSG_DATA */
+
+/*
+ * RFC 2292 requires to check msg_controllen, in case that the kernel returns
+ * an empty list for some reasons.
+ */
+#ifndef CMSG_FIRSTHDR
+#define CMSG_FIRSTHDR(mhdr) \
+	((mhdr)->msg_controllen >= sizeof(struct cmsghdr) ? \
+	 (struct cmsghdr *)(mhdr)->msg_control : \
+	 (struct cmsghdr *)NULL)
+#endif /* CMSG_FIRSTHDR */
+
+#if defined(HAVE_DECL_OFFSETOF) && HAVE_DECL_OFFSETOF == 0
+# define offsetof(type, member) ((size_t) &((type *)0)->member)
+#endif
+
+/* Set up BSD-style BYTE_ORDER definition if it isn't there already */
+/* XXX: doesn't try to cope with strange byte orders (PDP_ENDIAN) */
+#ifndef BYTE_ORDER
+# ifndef LITTLE_ENDIAN
+#  define LITTLE_ENDIAN  1234
+# endif /* LITTLE_ENDIAN */
+# ifndef BIG_ENDIAN
+#  define BIG_ENDIAN     4321
+# endif /* BIG_ENDIAN */
+# ifdef WORDS_BIGENDIAN
+#  define BYTE_ORDER BIG_ENDIAN
+# else /* WORDS_BIGENDIAN */
+#  define BYTE_ORDER LITTLE_ENDIAN
+# endif /* WORDS_BIGENDIAN */
+#endif /* BYTE_ORDER */
+
+/* Function replacement / compatibility hacks */
+
+#if !defined(HAVE_GETADDRINFO) && (defined(HAVE_OGETADDRINFO) || defined(HAVE_NGETADDRINFO))
+# define HAVE_GETADDRINFO
+#endif
+
+#ifndef HAVE_GETOPT_OPTRESET
+# undef getopt
+# undef opterr
+# undef optind
+# undef optopt
+# undef optreset
+# undef optarg
+# define getopt(ac, av, o)  BSDgetopt(ac, av, o)
+# define opterr             BSDopterr
+# define optind             BSDoptind
+# define optopt             BSDoptopt
+# define optreset           BSDoptreset
+# define optarg             BSDoptarg
+#endif
+
+#if defined(BROKEN_GETADDRINFO) && defined(HAVE_GETADDRINFO)
+# undef HAVE_GETADDRINFO
+#endif
+#if defined(BROKEN_GETADDRINFO) && defined(HAVE_FREEADDRINFO)
+# undef HAVE_FREEADDRINFO
+#endif
+#if defined(BROKEN_GETADDRINFO) && defined(HAVE_GAI_STRERROR)
+# undef HAVE_GAI_STRERROR
+#endif
+
+#if defined(BROKEN_UPDWTMPX) && defined(HAVE_UPDWTMPX)
+# undef HAVE_UPDWTMPX
+#endif
+
+#if defined(BROKEN_SHADOW_EXPIRE) && defined(HAS_SHADOW_EXPIRE)
+# undef HAS_SHADOW_EXPIRE
+#endif
+
+#if defined(HAVE_OPENLOG_R) && defined(SYSLOG_DATA_INIT) && \
+    defined(SYSLOG_R_SAFE_IN_SIGHAND)
+# define DO_LOG_SAFE_IN_SIGHAND
+#endif
+
+#if !defined(HAVE_MEMMOVE) && defined(HAVE_BCOPY)
+# define memmove(s1, s2, n) bcopy((s2), (s1), (n))
+#endif /* !defined(HAVE_MEMMOVE) && defined(HAVE_BCOPY) */
+
+#if defined(HAVE_VHANGUP) && !defined(HAVE_DEV_PTMX)
+#  define USE_VHANGUP
+#endif /* defined(HAVE_VHANGUP) && !defined(HAVE_DEV_PTMX) */
+
+#ifndef GETPGRP_VOID
+//# include <unistd.h>
+# define getpgrp() getpgrp(0)
+#endif
+
+#ifdef USE_BSM_AUDIT
+# define SSH_AUDIT_EVENTS
+# define CUSTOM_SSH_AUDIT_EVENTS
+#endif
+
+#if !defined(HAVE___func__) && defined(HAVE___FUNCTION__)
+#  define __func__ __FUNCTION__
+#elif !defined(HAVE___func__)
+#  define __func__ ""
+#endif
+
+#if defined(KRB5) && !defined(HEIMDAL)
+#  define krb5_get_err_text(context,code) error_message(code)
+#endif
+
+#if defined(SKEYCHALLENGE_4ARG)
+# define _compat_skeychallenge(a,b,c,d) skeychallenge(a,b,c,d)
+#else
+# define _compat_skeychallenge(a,b,c,d) skeychallenge(a,b,c)
+#endif
+
+/* Maximum number of file descriptors available */
+#ifdef HAVE_SYSCONF
+# define SSH_SYSFDMAX sysconf(_SC_OPEN_MAX)
+#else
+# define SSH_SYSFDMAX 10000
+#endif
+
+#ifdef FSID_HAS_VAL
+/* encode f_fsid into a 64 bit value  */
+#define FSID_TO_ULONG(f) \
+	((((u_int64_t)(f).val[0] & 0xffffffffUL) << 32) | \
+	    ((f).val[1] & 0xffffffffUL))
+#else
+# define FSID_TO_ULONG(f) ((f))
+#endif
+
+#if defined(__Lynx__)
+ /*
+  * LynxOS defines these in param.h which we do not want to include since
+  * it will also pull in a bunch of kernel definitions.
+  */
+# define ALIGNBYTES (sizeof(int) - 1)
+# define ALIGN(p) (((unsigned)p + ALIGNBYTES) & ~ALIGNBYTES)
+  /* Missing prototypes on LynxOS */
+  int snprintf (char *, size_t, const char *, ...);
+  int mkstemp (char *);
+  char *crypt (const char *, const char *);
+  int seteuid (uid_t);
+  int setegid (gid_t);
+  char *mkdtemp (char *);
+  int rresvport_af (int *, sa_family_t);
+  int innetgr (const char *, const char *, const char *, const char *);
+#endif
+
+/*
+ * Define this to use pipes instead of socketpairs for communicating with the
+ * client program.  Socketpairs do not seem to work on all systems.
+ *
+ * configure.ac sets this for a few OS's which are known to have problems
+ * but you may need to set it yourself
+ */
+/* #define USE_PIPES 1 */
+
+/**
+ ** login recorder definitions
+ **/
+
+/* FIXME: put default paths back in */
+#ifndef UTMP_FILE
+#  ifdef _PATH_UTMP
+#    define UTMP_FILE _PATH_UTMP
+#  else
+#    ifdef CONF_UTMP_FILE
+#      define UTMP_FILE CONF_UTMP_FILE
+#    endif
+#  endif
+#endif
+#ifndef WTMP_FILE
+#  ifdef _PATH_WTMP
+#    define WTMP_FILE _PATH_WTMP
+#  else
+#    ifdef CONF_WTMP_FILE
+#      define WTMP_FILE CONF_WTMP_FILE
+#    endif
+#  endif
+#endif
+/* pick up the user's location for lastlog if given */
+#ifndef LASTLOG_FILE
+#  ifdef _PATH_LASTLOG
+#    define LASTLOG_FILE _PATH_LASTLOG
+#  else
+#    ifdef CONF_LASTLOG_FILE
+#      define LASTLOG_FILE CONF_LASTLOG_FILE
+#    endif
+#  endif
+#endif
+
+#if defined(HAVE_SHADOW_H) && !defined(DISABLE_SHADOW)
+# define USE_SHADOW
+#endif
+
+/* The login() library function in libutil is first choice */
+#if defined(HAVE_LOGIN) && !defined(DISABLE_LOGIN)
+#  define USE_LOGIN
+
+#else
+/* Simply select your favourite login types. */
+/* Can't do if-else because some systems use several... <sigh> */
+#  if defined(UTMPX_FILE) && !defined(DISABLE_UTMPX)
+#    define USE_UTMPX
+#  endif
+#  if defined(UTMP_FILE) && !defined(DISABLE_UTMP)
+#    define USE_UTMP
+#  endif
+#  if defined(WTMPX_FILE) && !defined(DISABLE_WTMPX)
+#    define USE_WTMPX
+#  endif
+#  if defined(WTMP_FILE) && !defined(DISABLE_WTMP)
+#    define USE_WTMP
+#  endif
+
+#endif
+
+#ifndef UT_LINESIZE
+# define UT_LINESIZE 8
+#endif
+
+/* I hope that the presence of LASTLOG_FILE is enough to detect this */
+#if defined(LASTLOG_FILE) && !defined(DISABLE_LASTLOG)
+#  define USE_LASTLOG
+#endif
+
+#ifdef HAVE_OSF_SIA
+# ifdef USE_SHADOW
+#  undef USE_SHADOW
+# endif
+# define CUSTOM_SYS_AUTH_PASSWD 1
+#endif
+
+#if defined(HAVE_LIBIAF) && defined(HAVE_SET_ID) && !defined(HAVE_SECUREWARE)
+# define CUSTOM_SYS_AUTH_PASSWD 1
+#endif
+#if defined(HAVE_LIBIAF) && defined(HAVE_SET_ID) && !defined(BROKEN_LIBIAF)
+# define USE_LIBIAF
+#endif
+
+/* HP-UX 11.11 */
+#ifdef BTMP_FILE
+# define _PATH_BTMP BTMP_FILE
+#endif
+
+#if defined(USE_BTMP) && defined(_PATH_BTMP)
+# define CUSTOM_FAILED_LOGIN
+#endif
+
+/** end of login recorder definitions */
+
+#ifdef BROKEN_GETGROUPS
+# define getgroups(a,b) ((a)==0 && (b)==NULL ? NGROUPS_MAX : getgroups((a),(b)))
+#endif
+
+#if defined(HAVE_MMAP) && defined(BROKEN_MMAP)
+# undef HAVE_MMAP
+#endif
+
+#ifndef IOV_MAX
+# if defined(_XOPEN_IOV_MAX)
+#  define	IOV_MAX		_XOPEN_IOV_MAX
+# elif defined(DEF_IOV_MAX)
+#  define	IOV_MAX		DEF_IOV_MAX
+# else
+#  define	IOV_MAX		16
+# endif
+#endif
+
+#ifndef EWOULDBLOCK
+# define EWOULDBLOCK EAGAIN
+#endif
+
+#ifndef INET6_ADDRSTRLEN	/* for non IPv6 machines */
+#define INET6_ADDRSTRLEN 46
+#endif
+
+#endif /* _DEFINES_H */

--- a/obfuscate.c
+++ b/obfuscate.c
@@ -1,0 +1,516 @@
+/* Per Bruce Leidl, author of the obfuscated-openssh patch...
+
+"Obfuscated-openssh is just a patch to the main OpenSSH code.  It is released under the same license as OpenSSH."
+
+Therefore the following has been included.
+
+Mr. Hinky Dink */
+
+/*
+This file is part of the OpenSSH software.
+
+The licences which components of this software fall under are as
+follows.  First, we will summarize and say that all components
+are under a BSD licence, or a licence more free than that.
+
+OpenSSH contains no GPL code.
+
+1)
+     * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+     *                    All rights reserved
+     *
+     * As far as I am concerned, the code I have written for this software
+     * can be used freely for any purpose.  Any derived versions of this
+     * software must be clearly marked as such, and if the derived work is
+     * incompatible with the protocol description in the RFC file, it must be
+     * called by a name other than "ssh" or "Secure Shell".
+
+    [Tatu continues]
+     *  However, I am not implying to give any licenses to any patents or
+     * copyrights held by third parties, and the software includes parts that
+     * are not under my direct control.  As far as I know, all included
+     * source code is used in accordance with the relevant license agreements
+     * and can be used freely for any purpose (the GNU license being the most
+     * restrictive); see below for details.
+
+    [However, none of that term is relevant at this point in time.  All of
+    these restrictively licenced software components which he talks about
+    have been removed from OpenSSH, i.e.,
+
+     - RSA is no longer included, found in the OpenSSL library
+     - IDEA is no longer included, its use is deprecated
+     - DES is now external, in the OpenSSL library
+     - GMP is no longer used, and instead we call BN code from OpenSSL
+     - Zlib is now external, in a library
+     - The make-ssh-known-hosts script is no longer included
+     - TSS has been removed
+     - MD5 is now external, in the OpenSSL library
+     - RC4 support has been replaced with ARC4 support from OpenSSL
+     - Blowfish is now external, in the OpenSSL library
+
+    [The licence continues]
+
+    Note that any information and cryptographic algorithms used in this
+    software are publicly available on the Internet and at any major
+    bookstore, scientific library, and patent office worldwide.  More
+    information can be found e.g. at "http://www.cs.hut.fi/crypto".
+
+    The legal status of this program is some combination of all these
+    permissions and restrictions.  Use only at your own responsibility.
+    You will be responsible for any legal consequences yourself; I am not
+    making any claims whether possessing or using this is legal or not in
+    your country, and I am not taking any responsibility on your behalf.
+
+
+			    NO WARRANTY
+
+    BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+    FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+    OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+    PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+    OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+    TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+    PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+    REPAIR OR CORRECTION.
+
+    IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+    WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+    REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+    INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+    OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+    TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+    YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+    PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGES.
+
+2)
+    The 32-bit CRC compensation attack detector in deattack.c was
+    contributed by CORE SDI S.A. under a BSD-style license.
+
+     * Cryptographic attack detector for ssh - source code
+     *
+     * Copyright (c) 1998 CORE SDI S.A., Buenos Aires, Argentina.
+     *
+     * All rights reserved. Redistribution and use in source and binary
+     * forms, with or without modification, are permitted provided that
+     * this copyright notice is retained.
+     *
+     * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES ARE DISCLAIMED. IN NO EVENT SHALL CORE SDI S.A. BE
+     * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+     * CONSEQUENTIAL DAMAGES RESULTING FROM THE USE OR MISUSE OF THIS
+     * SOFTWARE.
+     *
+     * Ariel Futoransky <futo@core-sdi.com>
+     * <http://www.core-sdi.com>
+
+3)
+    ssh-keyscan was contributed by David Mazieres under a BSD-style
+    license.
+
+     * Copyright 1995, 1996 by David Mazieres <dm@lcs.mit.edu>.
+     *
+     * Modification and redistribution in source and binary forms is
+     * permitted provided that due credit is given to the author and the
+     * OpenBSD project by leaving this copyright notice intact.
+
+4)
+    The Rijndael implementation by Vincent Rijmen, Antoon Bosselaers
+    and Paulo Barreto is in the public domain and distributed
+    with the following license:
+
+     * @version 3.0 (December 2000)
+     *
+     * Optimised ANSI C code for the Rijndael cipher (now AES)
+     *
+     * @author Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
+     * @author Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>
+     * @author Paulo Barreto <paulo.barreto@terra.com.br>
+     *
+     * This code is hereby placed in the public domain.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ''AS IS'' AND ANY EXPRESS
+     * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+     * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+     * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE
+     * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+     * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+     * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+     * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+     * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+5)
+    One component of the ssh source code is under a 3-clause BSD license,
+    held by the University of California, since we pulled these parts from
+    original Berkeley code.
+
+     * Copyright (c) 1983, 1990, 1992, 1993, 1995
+     *      The Regents of the University of California.  All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without
+     * modification, are permitted provided that the following conditions
+     * are met:
+     * 1. Redistributions of source code must retain the above copyright
+     *    notice, this list of conditions and the following disclaimer.
+     * 2. Redistributions in binary form must reproduce the above copyright
+     *    notice, this list of conditions and the following disclaimer in the
+     *    documentation and/or other materials provided with the distribution.
+     * 3. Neither the name of the University nor the names of its contributors
+     *    may be used to endorse or promote products derived from this software
+     *    without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+     * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+     * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+     * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+     * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+     * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+     * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+     * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+     * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+     * SUCH DAMAGE.
+
+6)
+    Remaining components of the software are provided under a standard
+    2-term BSD licence with the following names as copyright holders:
+
+	Markus Friedl
+	Theo de Raadt
+	Niels Provos
+	Dug Song
+	Aaron Campbell
+	Damien Miller
+	Kevin Steves
+	Daniel Kouril
+	Wesley Griffin
+	Per Allansson
+	Nils Nordman
+	Simon Wilkinson
+
+    Portable OpenSSH additionally includes code from the following copyright
+    holders, also under the 2-term BSD license:
+
+	Ben Lindstrom
+	Tim Rice
+	Andre Lucas
+	Chris Adams
+	Corinna Vinschen
+	Cray Inc.
+	Denis Parker
+	Gert Doering
+	Jakob Schlyter
+	Jason Downs
+	Juha Yrj?l?
+	Michael Stone
+	Networks Associates Technology, Inc.
+	Solar Designer
+	Todd C. Miller
+	Wayne Schroeder
+	William Jones
+	Darren Tucker
+	Sun Microsystems
+	The SCO Group
+	Daniel Walsh
+
+     * Redistribution and use in source and binary forms, with or without
+     * modification, are permitted provided that the following conditions
+     * are met:
+     * 1. Redistributions of source code must retain the above copyright
+     *    notice, this list of conditions and the following disclaimer.
+     * 2. Redistributions in binary form must reproduce the above copyright
+     *    notice, this list of conditions and the following disclaimer in the
+     *    documentation and/or other materials provided with the distribution.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+     * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+     * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+     * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+     * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+     * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+     * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+     * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+     * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+     * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+8) Portable OpenSSH contains the following additional licenses:
+
+    a) md5crypt.c, md5crypt.h
+
+	 * "THE BEER-WARE LICENSE" (Revision 42):
+	 * <phk@login.dknet.dk> wrote this file.  As long as you retain this
+	 * notice you can do whatever you want with this stuff. If we meet
+	 * some day, and you think this stuff is worth it, you can buy me a
+	 * beer in return.   Poul-Henning Kamp
+
+    b) snprintf replacement
+
+	* Copyright Patrick Powell 1995
+	* This code is based on code written by Patrick Powell
+	* (papowell@astart.com) It may be used for any purpose as long as this
+	* notice remains intact on all source code distributions
+
+    c) Compatibility code (openbsd-compat)
+
+       Apart from the previously mentioned licenses, various pieces of code
+       in the openbsd-compat/ subdirectory are licensed as follows:
+
+       Some code is licensed under a 3-term BSD license, to the following
+       copyright holders:
+
+	Todd C. Miller
+	Theo de Raadt
+	Damien Miller
+	Eric P. Allman
+	The Regents of the University of California
+	Constantin S. Svintsoff
+
+	* Redistribution and use in source and binary forms, with or without
+	* modification, are permitted provided that the following conditions
+	* are met:
+	* 1. Redistributions of source code must retain the above copyright
+	*    notice, this list of conditions and the following disclaimer.
+	* 2. Redistributions in binary form must reproduce the above copyright
+	*    notice, this list of conditions and the following disclaimer in the
+	*    documentation and/or other materials provided with the distribution.
+	* 3. Neither the name of the University nor the names of its contributors
+	*    may be used to endorse or promote products derived from this software
+	*    without specific prior written permission.
+	*
+	* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+	* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+	* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+	* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+	* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+	* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+	* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+	* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+	* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+	* SUCH DAMAGE.
+
+       Some code is licensed under an ISC-style license, to the following
+       copyright holders:
+
+	Internet Software Consortium.
+	Todd C. Miller
+	Reyk Floeter
+	Chad Mynhier
+
+	* Permission to use, copy, modify, and distribute this software for any
+	* purpose with or without fee is hereby granted, provided that the above
+	* copyright notice and this permission notice appear in all copies.
+	*
+	* THE SOFTWARE IS PROVIDED "AS IS" AND TODD C. MILLER DISCLAIMS ALL
+	* WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+	* OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL TODD C. MILLER BE LIABLE
+	* FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+	* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+	* OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+	* CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+       Some code is licensed under a MIT-style license to the following
+       copyright holders:
+
+	Free Software Foundation, Inc.
+
+	* Permission is hereby granted, free of charge, to any person obtaining a  *
+	* copy of this software and associated documentation files (the            *
+	* "Software"), to deal in the Software without restriction, including      *
+	* without limitation the rights to use, copy, modify, merge, publish,      *
+	* distribute, distribute with modifications, sublicense, and/or sell       *
+	* copies of the Software, and to permit persons to whom the Software is    *
+	* furnished to do so, subject to the following conditions:                 *
+	*                                                                          *
+	* The above copyright notice and this permission notice shall be included  *
+	* in all copies or substantial portions of the Software.                   *
+	*                                                                          *
+	* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS  *
+	* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF               *
+	* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.   *
+	* IN NO EVENT SHALL THE ABOVE COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,   *
+	* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR    *
+	* OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR    *
+	* THE USE OR OTHER DEALINGS IN THE SOFTWARE.                               *
+	*                                                                          *
+	* Except as contained in this notice, the name(s) of the above copyright   *
+	* holders shall not be used in advertising or otherwise to promote the     *
+	* sale, use or other dealings in this Software without prior written       *
+	* authorization.                                                           *
+	****************************************************************************/
+
+
+#include "defines.h"
+#include <openssl/evp.h>
+#include <openssl/rc4.h>
+#include "arc4random.h"
+#include "obfuscate.h"
+
+#define OBFUSCATE_KEY_LENGTH 	16
+#define OBFUSCATE_SEED_LENGTH	16
+#define OBFUSCATE_HASH_ITERATIONS 6000
+#define OBFUSCATE_MAX_PADDING	8192
+#define OBFUSCATE_MAGIC_VALUE	0x0BF5CA7E
+
+static RC4_KEY rc4_input;
+static RC4_KEY rc4_output;
+
+static const char *obfuscate_keyword = NULL;
+
+
+struct seed_msg {
+	u_char seed_buffer[OBFUSCATE_SEED_LENGTH];
+	u_int32_t magic;
+	u_int32_t padding_length;
+	u_char padding[];
+};
+
+static int generate_key_pair(const u_char *, u_char *, u_char *);
+static int generate_key(const u_char *, const u_char *, u_int, u_char *);
+static void set_keys(const u_char *, const u_char *);
+static int initialize(const u_char *); // removed server flag
+
+/*
+ * Client calls this - removed socket for PoTTY
+ */
+
+extern int oblen;
+
+//THIS WORKS
+void * 
+obfuscate_send_seed(void)
+{
+	struct seed_msg *seed; 
+	int i;
+	
+	u_int32_t rnd = 0;
+	u_int message_length;
+	u_int32_t padding_length;
+	
+	padding_length = arc4random() % OBFUSCATE_MAX_PADDING;
+	message_length = padding_length + sizeof(struct seed_msg);
+	seed = malloc((size_t)message_length); // ssh.c frees mem
+
+	for(i = 0; i < OBFUSCATE_SEED_LENGTH; i++) {
+		if(i % 4 == 0)
+			rnd = arc4random();
+		seed->seed_buffer[i] = rnd & 0xff;
+		rnd >>= 8;
+	}
+	seed->magic = htonl(OBFUSCATE_MAGIC_VALUE);   // WTF?
+	seed->padding_length = htonl(padding_length); // ditto
+	for(i = 0; i < (int)padding_length; i++) {
+		if(i % 4 == 0)
+			rnd = arc4random();
+		seed->padding[i] = rnd & 0xff;
+	}
+	if ( initialize(seed->seed_buffer)){
+		free(seed);
+		return NULL;
+	}
+	obfuscate_output(((u_char *)seed) + OBFUSCATE_SEED_LENGTH,
+		message_length - OBFUSCATE_SEED_LENGTH);
+	oblen=message_length;
+
+	return (void *)seed;
+ }
+
+void
+obfuscate_set_keyword(const char *keyword)
+{
+	obfuscate_keyword = keyword;
+}
+
+void
+obfuscate_input(u_char *buffer, u_int buffer_len)
+{
+	RC4(&rc4_input, buffer_len, buffer, buffer);
+}
+
+void
+obfuscate_output(u_char *buffer, u_int buffer_len)
+{
+	RC4(&rc4_output, buffer_len, buffer, buffer);
+}
+
+static int
+initialize(const u_char *seed)
+{
+	u_char client_to_server_key[OBFUSCATE_KEY_LENGTH];
+	u_char server_to_client_key[OBFUSCATE_KEY_LENGTH];
+	
+	if( generate_key_pair(seed, client_to_server_key, server_to_client_key))
+		return 1;
+
+	set_keys(server_to_client_key, client_to_server_key);
+
+	return 0;
+}
+
+static int
+generate_key_pair(const u_char *seed, u_char *client_to_server_key, u_char *server_to_client_key)
+{
+	if( generate_key(seed, "client_to_server", strlen("client_to_server"), client_to_server_key))
+		return 1;
+	if( generate_key(seed, "server_to_client", strlen("server_to_client"), server_to_client_key))
+		return 1;
+	return 0;
+}
+
+static int
+generate_key(const u_char *seed, const u_char *iv, u_int iv_len, u_char *key_data)
+{
+	EVP_MD_CTX ctx;
+	u_char md_output[EVP_MAX_MD_SIZE];
+	int md_len;
+	int i;
+	u_char *buffer;
+	u_char *p;
+	u_int buffer_length;
+
+	buffer_length = OBFUSCATE_SEED_LENGTH + iv_len;
+	if(obfuscate_keyword)
+		buffer_length += strlen(obfuscate_keyword);
+
+	p = buffer = malloc(buffer_length);
+
+	memcpy(p, seed, OBFUSCATE_SEED_LENGTH);
+	p += OBFUSCATE_SEED_LENGTH;
+
+	if(obfuscate_keyword) {
+		memcpy(p, obfuscate_keyword, strlen(obfuscate_keyword));
+		p += strlen(obfuscate_keyword);
+	}
+	memcpy(p, iv, iv_len);
+
+	EVP_DigestInit(&ctx, EVP_sha1());
+	EVP_DigestUpdate(&ctx, buffer, OBFUSCATE_SEED_LENGTH + iv_len);
+	EVP_DigestFinal(&ctx, md_output, &md_len);
+
+	free(buffer);
+
+	for(i = 0; i < OBFUSCATE_HASH_ITERATIONS; i++) {
+		EVP_DigestInit(&ctx, EVP_sha1());
+		EVP_DigestUpdate(&ctx, md_output, md_len);
+		EVP_DigestFinal(&ctx, md_output, &md_len);
+	}
+
+	// Error designed to fail in CLI environment
+	// ssh.c now handles with bombout(msg)
+	if(md_len < OBFUSCATE_KEY_LENGTH) return 1; 
+		//fatal("Cannot derive obfuscation keys from hash length of %d", md_len);
+
+	memcpy(key_data, md_output, OBFUSCATE_KEY_LENGTH);
+
+	return 0;
+}
+
+static void
+set_keys(const u_char *input_key, const u_char *output_key)
+{
+	RC4_set_key(&rc4_input, OBFUSCATE_KEY_LENGTH, input_key);
+	RC4_set_key(&rc4_output, OBFUSCATE_KEY_LENGTH, output_key);
+}

--- a/obfuscate.h
+++ b/obfuscate.h
@@ -1,0 +1,357 @@
+/* Per Bruce Leidl, author of the obfuscated-openssh patch...
+
+"Obfuscated-openssh is just a patch to the main OpenSSH code.  It is released under the same license as OpenSSH."
+
+Therefore the following has been included.
+
+Mr. Hinky Dink */
+
+/*
+This file is part of the OpenSSH software.
+
+The licences which components of this software fall under are as
+follows.  First, we will summarize and say that all components
+are under a BSD licence, or a licence more free than that.
+
+OpenSSH contains no GPL code.
+
+1)
+     * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+     *                    All rights reserved
+     *
+     * As far as I am concerned, the code I have written for this software
+     * can be used freely for any purpose.  Any derived versions of this
+     * software must be clearly marked as such, and if the derived work is
+     * incompatible with the protocol description in the RFC file, it must be
+     * called by a name other than "ssh" or "Secure Shell".
+
+    [Tatu continues]
+     *  However, I am not implying to give any licenses to any patents or
+     * copyrights held by third parties, and the software includes parts that
+     * are not under my direct control.  As far as I know, all included
+     * source code is used in accordance with the relevant license agreements
+     * and can be used freely for any purpose (the GNU license being the most
+     * restrictive); see below for details.
+
+    [However, none of that term is relevant at this point in time.  All of
+    these restrictively licenced software components which he talks about
+    have been removed from OpenSSH, i.e.,
+
+     - RSA is no longer included, found in the OpenSSL library
+     - IDEA is no longer included, its use is deprecated
+     - DES is now external, in the OpenSSL library
+     - GMP is no longer used, and instead we call BN code from OpenSSL
+     - Zlib is now external, in a library
+     - The make-ssh-known-hosts script is no longer included
+     - TSS has been removed
+     - MD5 is now external, in the OpenSSL library
+     - RC4 support has been replaced with ARC4 support from OpenSSL
+     - Blowfish is now external, in the OpenSSL library
+
+    [The licence continues]
+
+    Note that any information and cryptographic algorithms used in this
+    software are publicly available on the Internet and at any major
+    bookstore, scientific library, and patent office worldwide.  More
+    information can be found e.g. at "http://www.cs.hut.fi/crypto".
+
+    The legal status of this program is some combination of all these
+    permissions and restrictions.  Use only at your own responsibility.
+    You will be responsible for any legal consequences yourself; I am not
+    making any claims whether possessing or using this is legal or not in
+    your country, and I am not taking any responsibility on your behalf.
+
+
+			    NO WARRANTY
+
+    BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+    FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+    OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+    PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+    OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+    TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+    PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+    REPAIR OR CORRECTION.
+
+    IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+    WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+    REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+    INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+    OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+    TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+    YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+    PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGES.
+
+2)
+    The 32-bit CRC compensation attack detector in deattack.c was
+    contributed by CORE SDI S.A. under a BSD-style license.
+
+     * Cryptographic attack detector for ssh - source code
+     *
+     * Copyright (c) 1998 CORE SDI S.A., Buenos Aires, Argentina.
+     *
+     * All rights reserved. Redistribution and use in source and binary
+     * forms, with or without modification, are permitted provided that
+     * this copyright notice is retained.
+     *
+     * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES ARE DISCLAIMED. IN NO EVENT SHALL CORE SDI S.A. BE
+     * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+     * CONSEQUENTIAL DAMAGES RESULTING FROM THE USE OR MISUSE OF THIS
+     * SOFTWARE.
+     *
+     * Ariel Futoransky <futo@core-sdi.com>
+     * <http://www.core-sdi.com>
+
+3)
+    ssh-keyscan was contributed by David Mazieres under a BSD-style
+    license.
+
+     * Copyright 1995, 1996 by David Mazieres <dm@lcs.mit.edu>.
+     *
+     * Modification and redistribution in source and binary forms is
+     * permitted provided that due credit is given to the author and the
+     * OpenBSD project by leaving this copyright notice intact.
+
+4)
+    The Rijndael implementation by Vincent Rijmen, Antoon Bosselaers
+    and Paulo Barreto is in the public domain and distributed
+    with the following license:
+
+     * @version 3.0 (December 2000)
+     *
+     * Optimised ANSI C code for the Rijndael cipher (now AES)
+     *
+     * @author Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
+     * @author Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>
+     * @author Paulo Barreto <paulo.barreto@terra.com.br>
+     *
+     * This code is hereby placed in the public domain.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ''AS IS'' AND ANY EXPRESS
+     * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+     * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+     * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE
+     * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+     * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+     * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+     * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+     * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+5)
+    One component of the ssh source code is under a 3-clause BSD license,
+    held by the University of California, since we pulled these parts from
+    original Berkeley code.
+
+     * Copyright (c) 1983, 1990, 1992, 1993, 1995
+     *      The Regents of the University of California.  All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without
+     * modification, are permitted provided that the following conditions
+     * are met:
+     * 1. Redistributions of source code must retain the above copyright
+     *    notice, this list of conditions and the following disclaimer.
+     * 2. Redistributions in binary form must reproduce the above copyright
+     *    notice, this list of conditions and the following disclaimer in the
+     *    documentation and/or other materials provided with the distribution.
+     * 3. Neither the name of the University nor the names of its contributors
+     *    may be used to endorse or promote products derived from this software
+     *    without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+     * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+     * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+     * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+     * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+     * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+     * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+     * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+     * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+     * SUCH DAMAGE.
+
+6)
+    Remaining components of the software are provided under a standard
+    2-term BSD licence with the following names as copyright holders:
+
+	Markus Friedl
+	Theo de Raadt
+	Niels Provos
+	Dug Song
+	Aaron Campbell
+	Damien Miller
+	Kevin Steves
+	Daniel Kouril
+	Wesley Griffin
+	Per Allansson
+	Nils Nordman
+	Simon Wilkinson
+
+    Portable OpenSSH additionally includes code from the following copyright
+    holders, also under the 2-term BSD license:
+
+	Ben Lindstrom
+	Tim Rice
+	Andre Lucas
+	Chris Adams
+	Corinna Vinschen
+	Cray Inc.
+	Denis Parker
+	Gert Doering
+	Jakob Schlyter
+	Jason Downs
+	Juha Yrj?l?
+	Michael Stone
+	Networks Associates Technology, Inc.
+	Solar Designer
+	Todd C. Miller
+	Wayne Schroeder
+	William Jones
+	Darren Tucker
+	Sun Microsystems
+	The SCO Group
+	Daniel Walsh
+
+     * Redistribution and use in source and binary forms, with or without
+     * modification, are permitted provided that the following conditions
+     * are met:
+     * 1. Redistributions of source code must retain the above copyright
+     *    notice, this list of conditions and the following disclaimer.
+     * 2. Redistributions in binary form must reproduce the above copyright
+     *    notice, this list of conditions and the following disclaimer in the
+     *    documentation and/or other materials provided with the distribution.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+     * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+     * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+     * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+     * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+     * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+     * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+     * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+     * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+     * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+8) Portable OpenSSH contains the following additional licenses:
+
+    a) md5crypt.c, md5crypt.h
+
+	 * "THE BEER-WARE LICENSE" (Revision 42):
+	 * <phk@login.dknet.dk> wrote this file.  As long as you retain this
+	 * notice you can do whatever you want with this stuff. If we meet
+	 * some day, and you think this stuff is worth it, you can buy me a
+	 * beer in return.   Poul-Henning Kamp
+
+    b) snprintf replacement
+
+	* Copyright Patrick Powell 1995
+	* This code is based on code written by Patrick Powell
+	* (papowell@astart.com) It may be used for any purpose as long as this
+	* notice remains intact on all source code distributions
+
+    c) Compatibility code (openbsd-compat)
+
+       Apart from the previously mentioned licenses, various pieces of code
+       in the openbsd-compat/ subdirectory are licensed as follows:
+
+       Some code is licensed under a 3-term BSD license, to the following
+       copyright holders:
+
+	Todd C. Miller
+	Theo de Raadt
+	Damien Miller
+	Eric P. Allman
+	The Regents of the University of California
+	Constantin S. Svintsoff
+
+	* Redistribution and use in source and binary forms, with or without
+	* modification, are permitted provided that the following conditions
+	* are met:
+	* 1. Redistributions of source code must retain the above copyright
+	*    notice, this list of conditions and the following disclaimer.
+	* 2. Redistributions in binary form must reproduce the above copyright
+	*    notice, this list of conditions and the following disclaimer in the
+	*    documentation and/or other materials provided with the distribution.
+	* 3. Neither the name of the University nor the names of its contributors
+	*    may be used to endorse or promote products derived from this software
+	*    without specific prior written permission.
+	*
+	* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+	* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+	* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+	* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+	* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+	* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+	* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+	* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+	* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+	* SUCH DAMAGE.
+
+       Some code is licensed under an ISC-style license, to the following
+       copyright holders:
+
+	Internet Software Consortium.
+	Todd C. Miller
+	Reyk Floeter
+	Chad Mynhier
+
+	* Permission to use, copy, modify, and distribute this software for any
+	* purpose with or without fee is hereby granted, provided that the above
+	* copyright notice and this permission notice appear in all copies.
+	*
+	* THE SOFTWARE IS PROVIDED "AS IS" AND TODD C. MILLER DISCLAIMS ALL
+	* WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+	* OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL TODD C. MILLER BE LIABLE
+	* FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+	* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+	* OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+	* CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+       Some code is licensed under a MIT-style license to the following
+       copyright holders:
+
+	Free Software Foundation, Inc.
+
+	* Permission is hereby granted, free of charge, to any person obtaining a  *
+	* copy of this software and associated documentation files (the            *
+	* "Software"), to deal in the Software without restriction, including      *
+	* without limitation the rights to use, copy, modify, merge, publish,      *
+	* distribute, distribute with modifications, sublicense, and/or sell       *
+	* copies of the Software, and to permit persons to whom the Software is    *
+	* furnished to do so, subject to the following conditions:                 *
+	*                                                                          *
+	* The above copyright notice and this permission notice shall be included  *
+	* in all copies or substantial portions of the Software.                   *
+	*                                                                          *
+	* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS  *
+	* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF               *
+	* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.   *
+	* IN NO EVENT SHALL THE ABOVE COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,   *
+	* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR    *
+	* OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR    *
+	* THE USE OR OTHER DEALINGS IN THE SOFTWARE.                               *
+	*                                                                          *
+	* Except as contained in this notice, the name(s) of the above copyright   *
+	* holders shall not be used in advertising or otherwise to promote the     *
+	* sale, use or other dealings in this Software without prior written       *
+	* authorization.                                                           *
+	****************************************************************************/
+
+
+#ifndef _OBFUSCATE_H
+#define _OBFUSCATE_H
+
+#define u_int unsigned int
+#define u_char unsigned char
+
+void *obfuscate_send_seed(void);
+void obfuscate_set_keyword(const char *);
+void obfuscate_input(u_char *, u_int);
+void obfuscate_output(u_char *, u_int);
+
+#endif

--- a/pscp.c
+++ b/pscp.c
@@ -2171,6 +2171,10 @@ static void usage(void)
     printf("  -unsafe   allow server-side wildcards (DANGEROUS)\n");
     printf("  -sftp     force use of SFTP protocol\n");
     printf("  -scp      force use of SCP protocol\n");
+    // brl+hinky
+    printf("  -z        obfuscate key exchange (SSH 2.0 only)\n");
+    printf("  -Z keywd  obfuscate with keyword (implies -z)\n");
+    // end b+h
 #if 0
     /*
      * -gui is an internal option, used by GUI front ends to get

--- a/psftp.c
+++ b/psftp.c
@@ -2626,6 +2626,10 @@ static void usage(void)
     printf("  -noagent  disable use of Pageant\n");
     printf("  -agent    enable use of Pageant\n");
     printf("  -batch    disable all interactive prompts\n");
+    // brl+hinky
+    printf("  -z        obfuscate key exchange (SSH2.0 only)\n");
+    printf("  -Z keywd  obfuscate with keyword (implies -z)\n");
+    // end b+h
     cleanup_exit(1);
 }
 

--- a/putty.h
+++ b/putty.h
@@ -546,6 +546,12 @@ struct config_tag {
     int ssh_no_shell;		       /* avoid running a shell */
     char ssh_nc_host[512];	       /* host to connect to in `nc' mode */
     int ssh_nc_port;		       /* port to connect to in `nc' mode */
+
+	/* Obfuscation Options by Mr Hinky Dink */
+
+	int obfuscate;
+	char obfuscate_keyword[64];
+	
     /* Telnet options */
     char termtype[32];
     char termspeed[32];

--- a/seed.h
+++ b/seed.h
@@ -1,0 +1,4 @@
+typedef struct obstruct {
+	void *ptr;
+	int len;
+}

--- a/windows/window.c
+++ b/windows/window.c
@@ -20,6 +20,7 @@
 #endif
 
 #define PUTTY_DO_GLOBALS	       /* actually _define_ globals */
+#define  SECURITY_WIN32 
 #include "putty.h"
 #include "terminal.h"
 #include "storage.h"

--- a/windows/wingss.c
+++ b/windows/wingss.c
@@ -1,5 +1,5 @@
 #ifndef NO_GSSAPI
-
+#define  SECURITY_WIN32 
 #include "putty.h"
 
 #include <security.h>

--- a/windows/winhelp.h
+++ b/windows/winhelp.h
@@ -101,6 +101,10 @@
 #define WINHELP_CTX_ssh_compress "ssh.compress:config-ssh-comp"
 #define WINHELP_CTX_ssh_kexlist "ssh.kex.order:config-ssh-kex-order"
 #define WINHELP_CTX_ssh_kex_repeat "ssh.kex.repeat:config-ssh-kex-rekey"
+// brl+hinky
+#define WINHELP_CTX_obfuscate "ssh.kex.obfuscate:config-ssh-kex-obfuscate"
+#define WINHELP_CTX_obfuscate_keyword "ssh.kex.obfuscate.keyword:config-ssh-kex-obfuscate-keyword"
+// end b+h
 #define WINHELP_CTX_ssh_auth_bypass "ssh.auth.bypass:config-ssh-noauth"
 #define WINHELP_CTX_ssh_auth_banner "ssh.auth.banner:config-ssh-banner"
 #define WINHELP_CTX_ssh_auth_privkey "ssh.auth.privkey:config-ssh-privkey"

--- a/windows/winmisc.c
+++ b/windows/winmisc.c
@@ -1,7 +1,7 @@
 /*
  * winmisc.c: miscellaneous Windows-specific things
  */
-
+#define  SECURITY_WIN32 
 #include <stdio.h>
 #include <stdlib.h>
 #include "putty.h"

--- a/windows/winplink.c
+++ b/windows/winplink.c
@@ -193,6 +193,8 @@ static void usage(void)
     printf("  -N        don't start a shell/command (SSH-2 only)\n");
     printf("  -nc host:port\n");
     printf("            open tunnel in place of session (SSH-2 only)\n");
+    printf("  -z        obfuscate key exchange (SSH-2 only)\n");
+	printf("  -Z keywd  obfuscate with keyword (SSH-2 only)\n");
     printf("  -sercfg configuration-string (e.g. 19200,8,n,1,X)\n");
     printf("            Specify the serial configuration (serial only)\n");
     exit(1);


### PR DESCRIPTION
An SSH SOCKS proxy is perfect proxy when you want to hide you tracks. However, some environments have deep packet inspection (DPI) equipment in place that blocks or throttles all encrypted online communications, rendering your secure SSH useless. 

This obfuscated feature can protect your ssh connection be detected by DPI equipment, it's very useful in some country like Iran.

See the following links:

https://github.com/brl/obfuscated-openssh/blob/7288432890c63dc228afe6c61e6343b72ef30962/README.obfuscation
