### PR TITLE
Bugfix

### DIFF
--- a/settings.c
+++ b/settings.c
@@ -608,10 +608,20 @@ void save_open_settings(void *sesskey, Config *cfg)
 void load_settings(char *section, Config * cfg)
 {
     void *sesskey;
+    int cur_storagetype = get_storagetype();
 
     sesskey = open_settings_r(section);
+    // Quick hack: if we are loading "default settings" but no
+    // such entry exists in registry, try file as well.
+    if (cur_storagetype == 0 && (!section || !*section) && !sesskey) {
+        set_storagetype(1);
+        sesskey = open_settings_r(section);
+    }
+
     load_open_settings(sesskey, cfg);
     close_settings_r(sesskey);
+
+    set_storagetype(cur_storagetype);
 
     if (cfg_launchable(cfg))
         add_session_to_jumplist(section);

--- a/storage.h
+++ b/storage.h
@@ -19,6 +19,7 @@
  * Function to force the storage loader to a certain type
  */
 void set_storagetype(int new_storagetype);
+int  get_storagetype();
 
 /*
  * Write a saved session. The caller is expected to call

--- a/windows/winstore.c
+++ b/windows/winstore.c
@@ -119,6 +119,9 @@ void set_storagetype(int new_storagetype)
 	storagetype = new_storagetype;
 }
 
+int  get_storagetype() {
+	return storagetype;
+}
 
 /*
  * Write a saved session. The caller is expected to call


### PR DESCRIPTION
Various bug fixes, details below:
1. fix vc project file generation.   b13cd5c
   Allow mkfiles.pl-generated VC6 project to compile successfully. Tested on VC++2012. 
2. Automatic switching between file and registry storage should be in sy… …  1f53379
   Related to #11, and a few other bugs like: Upon startuop, directly saving a new session will clear the session list, if all existing sessions are from file and hence auto storage type kicks in. 
3. Filter file-based sessions accordingly if session suffix is set.  15f76f4
4. Fix path bug in deleting session if session suffix is set.    ccf14e1
5. Handle NULL paramater in error message box.   b7ccb68
   Apr 29, 2013
6. Recognize "transport-usb", "transport-local" and "transport-any" for … …  c92eb0d
   #74
