### PR TITLE
improved paste delay

### DIFF
--- a/terminal.h
+++ b/terminal.h
@@ -152,6 +152,7 @@ struct terminal_tag {
     int big_cursor;
 
     int pastedelay;
+	MMRESULT pasteDelayTimer_ID;	/* paste delay multimedia timer ID*/
 
     int xterm_mouse;		       /* send mouse messages to host */
     int xterm_extended_mouse;

--- a/windows/window.c
+++ b/windows/window.c
@@ -288,6 +288,11 @@ enum {
 
 static int urlhack_cursor_is_hand = 0;
 
+void CALLBACK pasteDelayTimer_callback(UINT uTimerID, UINT uMsg, DWORD_PTR param, DWORD_PTR dw1, DWORD_PTR dw2)
+{
+	term_paste(term);
+}
+
 /* Dummy routine, only required in plink. */
 void ldisc_update(void *frontend, int echo, int edit)
 {
@@ -1043,8 +1048,24 @@ int putty_main(HINSTANCE inst, HINSTANCE prev, LPSTR cmdline, int show)
 
 	    if (!(IsWindow(logbox) && IsDialogMessage(logbox, &msg)))
 		DispatchMessage(&msg);
-	    /* Send the paste buffer if there's anything to send */
-	    term_paste(term);
+		/* Send the paste buffer if there's anything to send */
+		if (term_paste_pending(term))
+		{
+			if (term->pastedelay != 0)
+			{
+				if (term->pasteDelayTimer_ID == 0)
+				{
+					term->pasteDelayTimer_ID = timeSetEvent(term->pastedelay, 0, pasteDelayTimer_callback, 0, TIME_PERIODIC);
+					if (term->pasteDelayTimer_ID == 0)
+					{   //problem creating MM timer
+
+					}
+				}
+			}
+			else {
+				term_paste(term);
+			}
+		}
 	    /* If there's nothing new in the queue then we can do everything
 	     * we've delayed, reading the socket, writing, and repainting
 	     * the window.


### PR DESCRIPTION
changed code around to use better, more accurate, multimedia timer instead of sleep(). Never used WM_TIMER in the end because it was REALLY inaccurate for anything below 300ms. Because the MM Timer uses it's own thread to call the callback there is no more locking of UI. 
