### PR TITLE
Fixing a bug in fetching session list from files

### DIFF
--- a/windows/winstore.c
+++ b/windows/winstore.c
@@ -1293,7 +1293,10 @@ char *file_enum_settings_next(void *handle, char *buffer, int buflen)
         //}
     }
     else if (e->fromFile) {
-        if (FindNextFile(e->hFile,&FindFileData) && !((FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) || FindFileData.cFileName[0] == '.')) { // HACK: PUTTY TRAY / PUTTY FILE: Fixed directory check
+        if (FindNextFile(e->hFile,&FindFileData)) {
+			if((FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) || FindFileData.cFileName[0] == '.') { // HACK: PUTTY TRAY / PUTTY FILE: Fixed directory check
+				return enum_settings_next(handle, buffer, buflen);
+			}
             unmungestr(FindFileData.cFileName, buffer, buflen);
             sfree(otherbuf);
             /* JK: cut off sessionsuffix */


### PR DESCRIPTION
While fetching session list from files, ignore folders and fetch next
available session file instead of returning null.

If you happen to have a stray folder in the sessions folder, then the
order in which FindNextFile() gets files is uncertain. And often we end up
seeing a folder traversed in the middle of several session files.

This issue is easily reproducable if we have lots of session files that
start with different names and a folder.
