### PR TITLE
Apply patch by 'unphased' to fix mouse wheel up events for vim (and others?)

### DIFF
--- a/terminal.c
+++ b/terminal.c
@@ -5977,7 +5977,9 @@ void term_mouse(Terminal *term, Mouse_Button braw, Mouse_Button bcooked,
 		term->mouse_is_down = 0;
 		break;
 	      case MA_CLICK:
-			  if (term->mouse_is_down == braw) {// HACK: ADDED FOR hyperlink stuff
+        // HACK: ADDED FOR hyperlink stuff
+        // MORE HACKING (@unphased: allow sequences of mouse wheel up and mouse wheel down to pass through)
+			  if (term->mouse_is_down == braw && braw != MBT_WHEEL_UP && braw != MBT_WHEEL_DOWN) {
 				  unlineptr(ldata); 
 				  return;
 			  }

--- a/windows/window.c
+++ b/windows/window.c
@@ -3781,10 +3781,12 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT message,
 				   TO_CHR_X(p.x),
 				   TO_CHR_Y(p.y), shift_pressed,
 				   control_pressed, is_alt_pressed());
-			term_mouse(term, b, translate_button(b),
-				   MA_RELEASE, TO_CHR_X(p.x),
-				   TO_CHR_Y(p.y), shift_pressed,
-				   control_pressed, is_alt_pressed());
+      // HACK (@unphased: I am removing the "button release" when triggered by
+      // mouse wheel to better replicate iTerm2's behavior)
+      // term_mouse(term, b, translate_button(b),
+			// 	   MA_RELEASE, TO_CHR_X(p.x),
+			// 	   TO_CHR_Y(p.y), shift_pressed,
+			// 	   control_pressed, is_alt_pressed());
 		    } /* else: not sure when this can fail */
 		} else {
                     if (control_pressed) {


### PR DESCRIPTION
See this discussion on gmane: http://comments.gmane.org/gmane.comp.terminal-emulators.tmux.user/5498

Original patch to putty-X: https://github.com/atsepkov/putty-X/commit/bbcedf5a85ca1ccaa27005e7f7ebeb4c8a783b88
