### PR TITLE
Patch to add gnome-like copy-paste shortcuts

### DIFF
--- a/config.c
+++ b/config.c
@@ -1805,11 +1805,6 @@ void setup_config_box(struct controlbox *b, int midsession,
 		  HELPCTX(selection_shiftdrag),
 		  conf_checkbox_handler, I(CONF_mouse_override));
 
-    /* url-cut */
-    ctrl_checkbox(s, "Detect URLs on selection and launch in browser", 'u',
-                  HELPCTX(selection_shiftdrag),
-                  conf_checkbox_handler, I(CONF_copy_clipbd_url_reg));
-
     ctrl_radiobuttons(s,
 		      "Default selection mode (Alt+drag does the other one):",
 		      NO_SHORTCUT, 2,

--- a/putty.h
+++ b/putty.h
@@ -835,6 +835,8 @@ void cleanup_exit(int);
     X(INT, NONE, mouse_override) \
     X(INT, NONE, copy_clipbd_url_reg) /* url-cut */ \
     X(INT, INT, wordness) \
+    /* Gnome CopyPast hack */ \
+    X(INT, NONE, gnomecp) \
     /* translations */ \
     X(INT, NONE, vtmode) \
     X(STR, NONE, line_codepage) \
@@ -1039,6 +1041,7 @@ int term_paste_pending(Terminal *);
 void term_paste(Terminal *);
 void term_nopaste(Terminal *);
 int term_ldisc(Terminal *, int option);
+void term_copy(Terminal *); /* Gnome CopyPast hack */
 void term_copyall(Terminal *);
 void term_reconfig(Terminal *, Conf *);
 void term_seen_key_event(Terminal *); 

--- a/settings.c
+++ b/settings.c
@@ -648,6 +648,8 @@ void save_open_settings(void *sesskey, Conf *conf)
 	}
 	write_setting_s(sesskey, buf, buf2);
     }
+	/* Gnome CopyPast hack */
+    write_setting_i(sesskey, "GnomeCP", conf_get_int(conf, CONF_gnomecp));
     write_setting_s(sesskey, "LineCodePage", conf_get_str(conf, CONF_line_codepage));
     write_setting_i(sesskey, "CJKAmbigWide", conf_get_int(conf, CONF_cjk_ambig_wide));
     write_setting_i(sesskey, "UTF8Override", conf_get_int(conf, CONF_utf8_override));
@@ -1016,6 +1018,8 @@ void load_open_settings(void *sesskey, Conf *conf)
 	}
 	sfree(buf2);
     }
+    /* Gnome CopyPast hack */
+    gppi(sesskey, "GnomeCP", 0, conf, CONF_gnomecp);
     /*
      * The empty default for LineCodePage will be converted later
      * into a plausible default for the locale.

--- a/terminal.c
+++ b/terminal.c
@@ -5571,6 +5571,16 @@ void clipme(Terminal *term, pos top, pos bottom, int rect, int desel,
     sfree(buf.attrbuf);
 }
 
+/* Gnome CopyPast hack */
+void term_copy(Terminal *term)
+{
+    if (term->selstate == SELECTED)
+    {
+        clipme(term, term->selstart, term->selend, 
+            (term->seltype == RECTANGULAR), FALSE, write_clip);
+    }
+}
+
 void term_copyall(Terminal *term)
 {
     pos top;
@@ -6133,8 +6143,9 @@ void term_mouse(Terminal *term, Mouse_Button braw, Mouse_Button bcooked,
 	     * We've completed a selection. We now transfer the
 	     * data to the clipboard.
 	     */
-	    clipme(term, term->selstart, term->selend,
-		   (term->seltype == RECTANGULAR), FALSE, write_clip);
+	    if (conf_get_int(term->conf, CONF_gnomecp) != 1) /* Gnome CopyPast hack */
+		    clipme(term, term->selstart, term->selend,
+			(term->seltype == RECTANGULAR), FALSE, write_clip);
 	    term->selstate = SELECTED;
 	} else
 	    term->selstate = NO_SELECTION;

--- a/windows/wincfg.c
+++ b/windows/wincfg.c
@@ -106,7 +106,7 @@ void win_setup_config_box(struct controlbox *b, HWND *hwndp, int has_help,
 			  int midsession, int protocol)
 {
     struct controlset *s;
-    union control *c;
+    union control *c, *c2;
     char *str;
     int col = 0;
     int cancelColumn;
@@ -374,14 +374,23 @@ void win_setup_config_box(struct controlbox *b, HWND *hwndp, int has_help,
 		      "Windows (Middle extends, Right brings up menu)", I(2),
 		      "Compromise (Middle extends, Right pastes)", I(0),
 		      "xterm (Middle pastes, Right extends)", I(1), NULL);
-    /*
+
+    /* Gnome CopyPast hack */
+    ctrl_checkbox(s, "Use Gnome-style copy/paste (Ctrl+Shift+C|V)", 'u',
+		HELPCTX(no_help),
+		conf_checkbox_handler, I(CONF_gnomecp));
+	/*
      * This really ought to go at the _top_ of its box, not the
      * bottom, so we'll just do some shuffling now we've set it
      * up...
      */
-    c = s->ctrls[s->ncontrols-1];      /* this should be the new control */
-    memmove(s->ctrls+1, s->ctrls, (s->ncontrols-1)*sizeof(union control *));
+    c = s->ctrls[s->ncontrols-2];      /* this should be the new control */
+	c2 = s->ctrls[s->ncontrols-1];      /* this should be the new control */
+    memmove(s->ctrls+2, s->ctrls, (s->ncontrols-2)*sizeof(union control *));
     s->ctrls[0] = c;
+	s->ctrls[1] = c2;
+    
+
 
     ctrl_checkbox(s, "Paste to clipboard in RTF as well as plain text", 'f',
 		HELPCTX(selection_rtf),
@@ -493,13 +502,18 @@ void win_setup_config_box(struct controlbox *b, HWND *hwndp, int has_help,
 		  HELPCTX(no_help),
 		  conf_checkbox_handler, I(CONF_url_ctrl_click));
 
+	/* url-cut -- windows only parameter for now */
+    ctrl_checkbox(s, "Detect URLs on selection and launch in browser", 'u',
+                  HELPCTX(selection_shiftdrag),
+                  conf_checkbox_handler, I(CONF_copy_clipbd_url_reg));
+
 	s = ctrl_getset(b, "Window/Hyperlinks", "browser", "Browser application");
 
 	ctrl_checkbox(s, "Use the default browser", 'b',
 		  HELPCTX(no_help),
 		  conf_checkbox_handler, I(CONF_url_defbrowser));
 
-	ctrl_filesel(s, "or specify an application to open hyperlinks with:", 's',
+	ctrl_filesel(s, "or specify an application to open hyperlinks with:", 'p',
 		"Application (*.exe)\0*.exe\0All files (*.*)\0*.*\0\0", TRUE,
 		"Select executable to open hyperlinks with", HELPCTX(no_help),
 		 conf_filesel_handler, I(CONF_url_browser));

--- a/windows/window.c
+++ b/windows/window.c
@@ -4695,6 +4695,16 @@ static int TranslateKey(UINT message, WPARAM wParam, LPARAM lParam,
 	    request_paste(NULL);
 	    return 0;
 	}
+	/* Gnome CopyPast hack */
+	if (conf_get_int(conf, CONF_gnomecp) && wParam == 'C' && shift_state == 3) {	/* Ctrl-Shift-C */
+	    term_copy(term);
+	    return 0;
+	}
+	if (conf_get_int(conf, CONF_gnomecp) && wParam == 'V' && shift_state == 3) {	/* Ctrl-Shift-V */
+	    request_paste(NULL);
+	    return 0;
+	}
+	/* Gnome CopyPast hack */
 	if (left_alt && wParam == VK_F4 && conf_get_int(conf, CONF_alt_f4)) {
 	    return -1;
 	}


### PR DESCRIPTION
This patch will add an option to allow gnome-like copy past shortcuts : Ctrl-Shift-C and Ctrl-Shift-V.
When enabled, it disables the auto copy on select feature (which can be annoying) but leave the right click paste according to the "xterm mouse" setting ("Comprimise" still Right-Paste, but if you select "Windows" you have a no mouse paste behaviour).

The "Detect URLs on selection and launch in browser" settings has been moved to make place for this option (plus, this setting is Windows only and it was in the multiplateform settings).
