### PR TITLE
Fix "sensible" url regex

### DIFF
--- a/settings.c
+++ b/settings.c
@@ -88,7 +88,8 @@ const char* urlhack_default_regex =
                     "tattoo|technology|tel|tips|today|tokyo|tools|top|town|toys|"
                     "trade|training|travel|university|uno|uol|vegas|ventures|"
                     "viajes|vision|vote|voyage|wales|wang|watch|webcam|website|"
-                    "wien|wiki|works|wtf|xxx|xyz|yandex|yokohama|youtube|zone"
+                    "wien|wiki|works|wtf|xxx|xyz|yandex|yokohama|youtube|zone|"
+                    "[a-zA-Z][a-zA-Z]"
                 ")"
             ")"
             "|([a-z]+[0-9]*)" // http://foo


### PR DESCRIPTION
Fixes commit f61c7101a200dc8969050f2416759632c781d317 (issue #163) which broke the "sensible" url regex for two letter TLDs
