### PR TITLE
Fix not being able to use non-SSH protocols

### DIFF
--- a/windows/window.c
+++ b/windows/window.c
@@ -342,7 +342,7 @@ static void start_backend(void)
     if (!realhost)
         realhost = _strdup("");
 
-    if (PROT_SSH != conf_get_int(conf, CONF_protocol)) {
+    if (error && PROT_SSH != conf_get_int(conf, CONF_protocol)) {
         fatalbox("%s", error);
     }
 


### PR DESCRIPTION
An attempt to correct https://github.com/FauxFaux/PuTTYTray/commit/158e7ac5feb0fd1531ed7775d520dd193c39c6f6 from preventing non-SSH connections altogether when "autoreconnect on wakeup from sleep" is enabled.

Error message I get when I try to telnet anywhere with autoreconnect enabled:
PuTTY Fatal Error: (null)

This might not be the fix final fix, but it should allow the non-SSH connections to at least work again.