### PR TITLE
Make mkfiles.pl bring in .cpp files as sources for generic build arti…

### DIFF
--- a/mkfiles.pl
+++ b/mkfiles.pl
@@ -194,6 +194,7 @@ foreach $i (@prognames) {
       push @scanlist, $file;
     } elsif ($j !~ /\./) {
       $file = "$j.c";
+      $file = "$j.cpp" unless &findfile($file);
       $file = "$j.m" unless &findfile($file);
       $depends{$j} = [$file];
       push @scanlist, $file;


### PR DESCRIPTION
Make mkfiles.pl bring in .cpp files as sources for generic build artifacts (no extension). Before, mkfiles.pl failed to run because the regex_lib target requires source file regex_lib.cpp, and mkfiles.pl didn't know to look for it. Fixes issue #280.